### PR TITLE
Add Restafari to test API

### DIFF
--- a/api_test/main.rest
+++ b/api_test/main.rest
@@ -1,0 +1,12 @@
+tests:
+- id: ping
+  path: /api
+  expect:
+    http: 200
+
+- id: load-fake-environment
+  path: /api/fake-env-laws
+  expect:
+    http: 200
+    data:
+      fake-env-laws: null 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bottle
+restafari


### PR DESCRIPTION
Add restafari module as required and a new simple rest file. 
After installing restafari, you can test the API by running:

```
 restafari -s localhost -P 9999 api_test/*
```
